### PR TITLE
Update the plugin to work with Android plugin 1.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,8 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile "commons-io:commons-io:2.4"
-    testCompile "com.android.tools.build:gradle:0.12.2"
-    testCompile "org.scala-lang:scala-compiler:2.11.5"
+    testCompile "com.android.tools.build:gradle:1.1.3"
+    testCompile "org.scala-lang:scala-compiler:2.11.6"
 }
 
 description "Gradle Android Scala Plugin adds scala language support to official gradle android plugin."

--- a/src/main/groovy/jp/leafytree/gradle/AndroidScalaPlugin.groovy
+++ b/src/main/groovy/jp/leafytree/gradle/AndroidScalaPlugin.groovy
@@ -208,7 +208,7 @@ public class AndroidScalaPlugin implements Plugin<Project> {
         scalaCompileTask.sourceCompatibility = javaCompileTask.sourceCompatibility
         scalaCompileTask.targetCompatibility = javaCompileTask.targetCompatibility
         scalaCompileTask.scalaCompileOptions.encoding = javaCompileTask.options.encoding
-        scalaCompileTask.classpath = javaCompileTask.classpath + project.files(androidPlugin.bootClasspath)
+        scalaCompileTask.classpath = javaCompileTask.classpath + project.files(androidPlugin.androidBuilder.bootClasspath)
         scalaCompileTask.scalaClasspath = compilerConfiguration.asFileTree
         scalaCompileTask.zincClasspath = zincConfiguration.asFileTree
         scalaCompileTask.scalaCompileOptions.incrementalOptions.analysisFile = new File(variantWorkDir, "analysis.txt")

--- a/src/test/groovy/jp/leafytree/gradle/AndroidScalaPluginTest.groovy
+++ b/src/test/groovy/jp/leafytree/gradle/AndroidScalaPluginTest.groovy
@@ -150,6 +150,6 @@ class AndroidScalaPluginTest {
     @Test
     public void scalaVersionFromClasspath() {
         def classpath = System.getProperty("java.class.path").split(File.pathSeparator).collect { new File(it) }
-        Assert.assertEquals("2.11.5", AndroidScalaPlugin.scalaVersionFromClasspath(classpath))
+        Assert.assertEquals("2.11.6", AndroidScalaPlugin.scalaVersionFromClasspath(classpath))
     }
 }


### PR DESCRIPTION
Note: This change is not backwards compatible with versions prior to
1.1.0. Some other language plugins jump through hoops to determine the
version being used, and then select the correct field dynamically. This
personally doesn't make sense to me, as the older version of the scala
plugin can continue to be used for those who need to use an older
version of the Gradle plugin.

I've also updated the readme as the `multiDexEnabled` option appears to
work just fine, now (and it is *ridiculously* fast after the first run,
as it's now incremental and doesn't need to calculate the main dex file)

Fixes #53