### PR TITLE
Add compile test task for scala plugin and update gradle and android plugins accordingly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 }
 
 description "Gradle Android Scala Plugin adds scala language support to official gradle android plugin."
-group = "jp.leafytree.gradle"
+group = "com.wire.gradle"
 version = "1.5-SNAPSHOT"
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6

--- a/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
+++ b/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
@@ -20,6 +20,11 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
 public class AndroidScalaPluginIntegrationTestTask extends DefaultTask {
+
+    static def GRADLE_VERSION = "2.12"
+    static def ANDROID_GRADLE_PLUGIN_VERSION = "1.5.0"
+    static def ANDROID_BUILD_TOOLS_VERSION = "23.0.3"
+
     @TaskAction
     def run() {
         def travis = System.getenv("TRAVIS").toString().toBoolean()
@@ -33,18 +38,18 @@ public class AndroidScalaPluginIntegrationTestTask extends DefaultTask {
                 ["useScalaOnlyTest", false],
                 ["apt", false],
         ].each { projectName, runOnTravis ->
-            def gradleArgs = ["clean", "connectedCheck", "uninstallAll"]
+            def gradleArgs = ["clean", "test", "connectedCheck", "uninstallAll"]
             [
-                    ["2.2.1", true,  "2.11.7", "1.3.1", "android-22", "22.0.1", "8", "23"],
-                    ["2.2.1", false, "2.10.5", "1.3.1", "android-22", "22.0.1", "8", "23"],
-                    ["2.2.1", false, "2.11.7", "1.3.1", "android-22", "22.0.1", "21", "23"],
-                    ["2.2.1", false, "2.10.5", "1.3.1", "android-22", "22.0.1", "21", "23"],
+                    [GRADLE_VERSION, true, "2.11.7", ANDROID_GRADLE_PLUGIN_VERSION, "android-22", ANDROID_BUILD_TOOLS_VERSION, "8", "23"],
+                    [GRADLE_VERSION, false, "2.10.5", ANDROID_GRADLE_PLUGIN_VERSION, "android-22", ANDROID_BUILD_TOOLS_VERSION, "8", "23"],
+                    [GRADLE_VERSION, false, "2.11.7", ANDROID_GRADLE_PLUGIN_VERSION, "android-22", ANDROID_BUILD_TOOLS_VERSION, "21", "23"],
+                    [GRADLE_VERSION, false, "2.10.5", ANDROID_GRADLE_PLUGIN_VERSION, "android-22", ANDROID_BUILD_TOOLS_VERSION, "21", "23"],
             ].each { testParameters ->
                 if (!travis || (runOnTravis && testParameters[1])) {
                     def gradleVersion = testParameters[0]
                     def gradleWrapperProperties = getGradleWrapperProperties(gradleVersion)
                     def gradleProperties = getGradleProperties(testParameters.drop(2))
-                    println "Test $gradleArgs gradleVersion:$gradleVersion $gradleProperties"
+                    println "Test $gradleArgs GRADLE_VERSION:$gradleVersion $gradleProperties"
                     runProject(projectName, gradleArgs, gradleWrapperProperties, gradleProperties)
                 }
             }

--- a/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
+++ b/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.tasks.TaskAction
 public class AndroidScalaPluginIntegrationTestTask extends DefaultTask {
 
     static def GRADLE_VERSION = "2.12"
-    static def ANDROID_GRADLE_PLUGIN_VERSION = "1.5.0"
+    static def ANDROID_GRADLE_PLUGIN_VERSION = "2.1.0"
     static def ANDROID_BUILD_TOOLS_VERSION = "23.0.3"
 
     @TaskAction

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 12 01:51:12 EEST 2016
+#Thu Jul 14 13:12:52 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-all.zip

--- a/src/integTest/app/build.gradle
+++ b/src/integTest/app/build.gradle
@@ -43,6 +43,7 @@ android {
 dependencies {
     compile "org.scala-lang:scala-library:$scalaLibraryVersion"
     compile "com.android.support:multidex:1.0.1"
+    testCompile "junit:junit:4.12"
     androidTestCompile "com.android.support:multidex-instrumentation:1.0.1", { exclude module: "multidex" }
 }
 

--- a/src/integTest/app/src/main/java/jp/leafytree/android/hello/HelloJava.java
+++ b/src/integTest/app/src/main/java/jp/leafytree/android/hello/HelloJava.java
@@ -4,4 +4,8 @@ public class HelloJava {
     public String say() {
         return "Hello. I'm Java !\n∀∁∂∃∄∅∆∇∈∉∊∋∌∍∎∏";
     }
+
+    public int increment(int i) {
+        return i + 1;
+    }
 }

--- a/src/integTest/app/src/main/scala/jp/leafytree/android/hello/HelloScala.scala
+++ b/src/integTest/app/src/main/scala/jp/leafytree/android/hello/HelloScala.scala
@@ -4,4 +4,8 @@ class HelloScala {
   def say = {
     "Hello. I'm Scala !\n℀℁ℂ℃℄℅℆ℇ℈℉ℊℋℌℍℎℏ"
   }
+
+  def increment(i: Int) = {
+    i + 1
+  }
 }

--- a/src/integTest/app/src/test/java/jp/leafytree/android/hello/HelloJavaTest.java
+++ b/src/integTest/app/src/test/java/jp/leafytree/android/hello/HelloJavaTest.java
@@ -1,0 +1,20 @@
+package jp.leafytree.android.hello;
+
+import org.junit.Test;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+import scala.collection.concurrent.TrieMap;
+
+public class HelloJavaTest {
+
+    @Test
+    public void simpleAssertion() {
+        assertTrue(true);
+    }
+
+    @Test
+    public void simpleActivityAssertion() {
+        assertEquals(3, new HelloJava().increment(2));
+    }
+}

--- a/src/integTest/app/src/test/scala/jp/leafytree/android/hello/HelloScalaTest.scala
+++ b/src/integTest/app/src/test/scala/jp/leafytree/android/hello/HelloScalaTest.scala
@@ -1,0 +1,19 @@
+package jp.leafytree.android.hello
+
+import junit.framework.Assert
+import org.junit.Test
+
+import scala.collection.concurrent.TrieMap
+
+class HelloScalaTest {
+
+  @Test
+  def simpleAssertion() {
+    Assert.assertTrue(true)
+  }
+
+  @Test
+  def simpleActivityAssertion() {
+    Assert.assertEquals(3, new HelloScala().increment(2))
+  }
+}

--- a/src/main/groovy/jp/leafytree/gradle/AndroidScalaPlugin.groovy
+++ b/src/main/groovy/jp/leafytree/gradle/AndroidScalaPlugin.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package jp.leafytree.gradle
+
 import com.google.common.annotations.VisibleForTesting
 import org.apache.commons.io.FileUtils
 import org.codehaus.groovy.runtime.InvokerHelper
@@ -22,9 +23,9 @@ import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
-import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.internal.file.DefaultSourceDirectorySetFactory
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.internal.tasks.DefaultScalaSourceSet
 import org.gradle.api.tasks.scala.ScalaCompile
 import org.gradle.util.ConfigureUtil
@@ -80,8 +81,10 @@ public class AndroidScalaPlugin implements Plugin<Project> {
 
         project.afterEvaluate {
             updateAndroidSourceSetsExtension()
-            androidExtension.sourceSets.each { it.java.srcDirs(it.scala.srcDirs) }
-            def allVariants = androidExtension.testVariants + (isLibrary ? androidExtension.libraryVariants : androidExtension.applicationVariants)
+            androidExtension.sourceSets.each { srcSet ->
+                srcSet.java.srcDirs(srcSet.scala.srcDirs)
+            }
+            def allVariants = androidExtension.testVariants + androidExtension.unitTestVariants + (isLibrary ? androidExtension.libraryVariants : androidExtension.applicationVariants)
             allVariants.each { variant ->
                 addAndroidScalaCompileTask(variant)
             }
@@ -173,6 +176,7 @@ public class AndroidScalaPlugin implements Plugin<Project> {
             def dirSetFactory = new DefaultSourceDirectorySetFactory(fileResolver, new DefaultDirectoryFileTreeFactory())
             sourceSet.convention.plugins.scala = new DefaultScalaSourceSet(sourceSet.name + "_AndroidScalaPlugin", dirSetFactory)
             def scala = sourceSet.scala
+
             scala.filter.include(include);
             def scalaSrcDir = ["src", sourceSet.name, "scala"].join(File.separator)
             scala.srcDir(scalaSrcDir)

--- a/src/test/groovy/jp/leafytree/gradle/AndroidScalaPluginTest.groovy
+++ b/src/test/groovy/jp/leafytree/gradle/AndroidScalaPluginTest.groovy
@@ -148,6 +148,17 @@ class AndroidScalaPluginTest {
     }
 
     @Test
+    public void updateCustomScalaUnitTestSourceSetToAndroidPlugin() {
+        def plugin = getPlugin()
+        def customSrc = new File(project.file("."), ["custom", "testSourceSet", "Src1Test.scala"].join(File.separator))
+        customSrc.parentFile.mkdirs()
+        customSrc.withWriter { it.write("class Src2Test{}") }
+        project.android { sourceSets { test { scala { srcDirs = ["custom/testSourceSet"] } } } }
+        Assert.assertEquals([], plugin.sourceDirectorySetMap["main"].files.toList().sort())
+        Assert.assertEquals([customSrc], plugin.sourceDirectorySetMap["test"].files.toList().sort())
+    }
+
+    @Test
     public void scalaVersionFromClasspath() {
         def classpath = System.getProperty("java.class.path").split(File.pathSeparator).collect { new File(it) }
         Assert.assertEquals("2.11.7", AndroidScalaPlugin.scalaVersionFromClasspath(classpath))


### PR DESCRIPTION
This commit ensures that the non-connected scala test variant gets included in the compilation task, adds a regular non-connected test directory to the app integration test for both Scala and Java, and updates the android plugin version to 1.5, the gradle version to 2.12, and the build tools versions to 23
