### PR TITLE
Changes made for compatibility with android gradle plugin 2.3.0 and Gradle 3.3, with Scala updated to 2.11.8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ See also sample projects at https://github.com/saturday06/gradle-android-scala-p
 
 | Scala  | Gradle | Android Plugin      | compileSdkVersion | buildToolsVersion |
 | ------ | ------ | ------------------- | ----------------- | ----------------- |
+| 2.11.8 | 3.3    | 2.3.0-beta2         | 25                | 25.0.2            |
 | 2.11.7 | 2.2.1  | 1.1.3, 1.2.3, 1.3.1 | 21, 22, 23        | 21.1.2, 22.0.1    |
 | 2.10.5 | 2.2.1  | 1.1.3, 1.2.3, 1.3.1 | 21, 22, 23        | 21.1.2, 22.0.1    |
 
@@ -41,8 +42,8 @@ please try [android-scala-plugin-1.3.2](https://github.com/saturday06/gradle-and
 ```groovy
 buildscript {
     dependencies {
-        classpath "com.android.tools.build:gradle:1.3.1"
-        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.4"
+        classpath "com.android.tools.build:gradle:2.3.0-beta2"
+        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }
 ```
@@ -62,7 +63,7 @@ The plugin decides scala language version using scala-library's version.
 `build.gradle`
 ```groovy
 dependencies {
-    compile "org.scala-lang:scala-library:2.11.7"
+    compile "org.scala-lang:scala-library:2.11.8"
 }
 ```
 
@@ -144,7 +145,7 @@ android {
 }
 
 dependencies {
-    compile "org.scala-lang:scala-library:2.11.7"
+    compile "org.scala-lang:scala-library:2.11.8"
     compile "com.android.support:multidex:1.0.1"
 }
 ```
@@ -173,7 +174,7 @@ android {
 }
 
 dependencies {
-    compile "org.scala-lang:scala-library:2.11.7"
+    compile "org.scala-lang:scala-library:2.11.8"
     compile "com.android.support:multidex:1.0.1"
     androidTestCompile "com.android.support:multidex-instrumentation:1.0.1", { exclude module: "multidex" }
 }
@@ -256,12 +257,13 @@ http://www.gradle.org/docs/current/dsl/org.gradle.api.tasks.scala.ScalaCompileOp
 ```groovy
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:1.3.1"
-        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.4"
+        classpath "com.android.tools.build:gradle:2.3.0-beta2"
+        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }
 
@@ -273,11 +275,11 @@ apply plugin: "com.android.application"
 apply plugin: "jp.leafytree.android-scala"
 
 android {
-    compileSdkVersion "android-22"
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
-        targetSdkVersion 22
+        targetSdkVersion 25
         testInstrumentationRunner "com.android.test.runner.MultiDexTestRunner"
         versionCode 1
         versionName "1.0"
@@ -310,7 +312,7 @@ android {
 }
 
 dependencies {
-    compile "org.scala-lang:scala-library:2.11.7"
+    compile "org.scala-lang:scala-library:2.11.8"
     compile "com.android.support:multidex:1.0.1"
     androidTestCompile "com.android.support:multidex-instrumentation:1.0.1", { exclude module: "multidex" }
 }
@@ -322,6 +324,7 @@ tasks.withType(ScalaCompile) {
 ```
 
 ## Changelog
+- 1.6 Support android plugin 2.3.0-beta2 and Gradle 3.3
 - 1.4 Support android plugin 1.1.3. Manual configuration for dex task is now unnecessary (contributed by [sgrif](https://github.com/sgrif))
 - 1.3.2 Fix unexpected annotation processor's warnings
 - 1.3.1 Support android plugin 0.12.2

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See also sample projects at https://github.com/saturday06/gradle-android-scala-p
 
 | Scala  | Gradle | Android Plugin      | compileSdkVersion | buildToolsVersion |
 | ------ | ------ | ------------------- | ----------------- | ----------------- |
-| 2.11.8 | 3.3    | 2.3.0-beta4         | 25                | 25.0.2            |
+| 2.11.8 | 3.3    | 2.3.0-rc1         | 25                | 25.0.2            |
 | 2.11.7 | 2.2.1  | 1.1.3, 1.2.3, 1.3.1 | 21, 22, 23        | 21.1.2, 22.0.1    |
 | 2.10.5 | 2.2.1  | 1.1.3, 1.2.3, 1.3.1 | 21, 22, 23        | 21.1.2, 22.0.1    |
 
@@ -46,7 +46,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta4'
+        classpath 'com.android.tools.build:gradle:2.3.0-rc1'
         classpath 'com.github.xingda920813:gradle-android-scala-plugin:java8'
     }
 }
@@ -265,7 +265,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta4'
+        classpath 'com.android.tools.build:gradle:2.3.0-rc1'
         classpath 'com.github.xingda920813:gradle-android-scala-plugin:java8'
     }
 }
@@ -327,7 +327,7 @@ tasks.withType(ScalaCompile) {
 ```
 
 ## Changelog
-- 1.6 Support android plugin 2.3.0-beta4 and Gradle 3.3
+- 1.6 Support android plugin 2.3.0-rc1 and Gradle 3.3
 - 1.4 Support android plugin 1.1.3. Manual configuration for dex task is now unnecessary (contributed by [sgrif](https://github.com/sgrif))
 - 1.3.2 Fix unexpected annotation processor's warnings
 - 1.3.1 Support android plugin 0.12.2

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See also sample projects at https://github.com/saturday06/gradle-android-scala-p
 
 | Scala  | Gradle | Android Plugin      | compileSdkVersion | buildToolsVersion |
 | ------ | ------ | ------------------- | ----------------- | ----------------- |
-| 2.11.8 | 3.3    | 2.3.0-rc1         | 25                | 25.0.2            |
+| 2.11.8 | 3.3    | 2.3.0               | 25                | 25.0.2            |
 | 2.11.7 | 2.2.1  | 1.1.3, 1.2.3, 1.3.1 | 21, 22, 23        | 21.1.2, 22.0.1    |
 | 2.10.5 | 2.2.1  | 1.1.3, 1.2.3, 1.3.1 | 21, 22, 23        | 21.1.2, 22.0.1    |
 
@@ -46,8 +46,8 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-rc1'
-        classpath 'com.github.xingda920813:gradle-android-scala-plugin:java8'
+        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.github.xingda920813:gradle-android-scala-plugin:android-gradle-2.3.0'
     }
 }
 ```
@@ -265,8 +265,8 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-rc1'
-        classpath 'com.github.xingda920813:gradle-android-scala-plugin:java8'
+        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.github.xingda920813:gradle-android-scala-plugin:android-gradle-2.3.0'
     }
 }
 
@@ -327,7 +327,7 @@ tasks.withType(ScalaCompile) {
 ```
 
 ## Changelog
-- 1.6 Support android plugin 2.3.0-rc1 and Gradle 3.3
+- 1.6 Support android plugin 2.3.0 and Gradle 3.3
 - 1.4 Support android plugin 1.1.3. Manual configuration for dex task is now unnecessary (contributed by [sgrif](https://github.com/sgrif))
 - 1.3.2 Fix unexpected annotation processor's warnings
 - 1.3.1 Support android plugin 0.12.2

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See also sample projects at https://github.com/saturday06/gradle-android-scala-p
 
 | Scala  | Gradle | Android Plugin      | compileSdkVersion | buildToolsVersion |
 | ------ | ------ | ------------------- | ----------------- | ----------------- |
-| 2.11.8 | 3.3    | 2.3.0-beta2         | 25                | 25.0.2            |
+| 2.11.8 | 3.3    | 2.3.0-beta3         | 25                | 25.0.2            |
 | 2.11.7 | 2.2.1  | 1.1.3, 1.2.3, 1.3.1 | 21, 22, 23        | 21.1.2, 22.0.1    |
 | 2.10.5 | 2.2.1  | 1.1.3, 1.2.3, 1.3.1 | 21, 22, 23        | 21.1.2, 22.0.1    |
 
@@ -46,7 +46,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta2'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta3'
         classpath 'com.github.xingda920813:gradle-android-scala-plugin:java8'
     }
 }
@@ -265,7 +265,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta2'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta3'
         classpath 'com.github.xingda920813:gradle-android-scala-plugin:java8'
     }
 }
@@ -327,7 +327,7 @@ tasks.withType(ScalaCompile) {
 ```
 
 ## Changelog
-- 1.6 Support android plugin 2.3.0-beta2 and Gradle 3.3
+- 1.6 Support android plugin 2.3.0-beta3 and Gradle 3.3
 - 1.4 Support android plugin 1.1.3. Manual configuration for dex task is now unnecessary (contributed by [sgrif](https://github.com/sgrif))
 - 1.3.2 Fix unexpected annotation processor's warnings
 - 1.3.1 Support android plugin 0.12.2

--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ please try [android-scala-plugin-1.3.2](https://github.com/saturday06/gradle-and
 `build.gradle`
 ```groovy
 buildscript {
+    repositories {
+        jcenter()
+        maven { url 'https://jitpack.io' }
+    }
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-beta2"
-        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
+        classpath 'com.android.tools.build:gradle:2.3.0-beta2'
+        classpath 'com.github.xingda920813:gradle-android-scala-plugin:java8'
     }
 }
 ```
@@ -258,12 +262,11 @@ http://www.gradle.org/docs/current/dsl/org.gradle.api.tasks.scala.ScalaCompileOp
 buildscript {
     repositories {
         jcenter()
-        mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
-
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-beta2"
-        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
+        classpath 'com.android.tools.build:gradle:2.3.0-beta2'
+        classpath 'com.github.xingda920813:gradle-android-scala-plugin:java8'
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See also sample projects at https://github.com/saturday06/gradle-android-scala-p
 
 | Scala  | Gradle | Android Plugin      | compileSdkVersion | buildToolsVersion |
 | ------ | ------ | ------------------- | ----------------- | ----------------- |
-| 2.11.8 | 3.3    | 2.3.0-beta3         | 25                | 25.0.2            |
+| 2.11.8 | 3.3    | 2.3.0-beta4         | 25                | 25.0.2            |
 | 2.11.7 | 2.2.1  | 1.1.3, 1.2.3, 1.3.1 | 21, 22, 23        | 21.1.2, 22.0.1    |
 | 2.10.5 | 2.2.1  | 1.1.3, 1.2.3, 1.3.1 | 21, 22, 23        | 21.1.2, 22.0.1    |
 
@@ -46,7 +46,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta3'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta4'
         classpath 'com.github.xingda920813:gradle-android-scala-plugin:java8'
     }
 }
@@ -265,7 +265,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta3'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta4'
         classpath 'com.github.xingda920813:gradle-android-scala-plugin:java8'
     }
 }
@@ -327,7 +327,7 @@ tasks.withType(ScalaCompile) {
 ```
 
 ## Changelog
-- 1.6 Support android plugin 2.3.0-beta3 and Gradle 3.3
+- 1.6 Support android plugin 2.3.0-beta4 and Gradle 3.3
 - 1.4 Support android plugin 1.1.3. Manual configuration for dex task is now unnecessary (contributed by [sgrif](https://github.com/sgrif))
 - 1.3.2 Fix unexpected annotation processor's warnings
 - 1.3.1 Support android plugin 0.12.2

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile "commons-io:commons-io:2.5"
-    testCompile "com.android.tools.build:gradle:2.3.0-rc1"
+    testCompile "com.android.tools.build:gradle:2.3.0"
     testCompile "org.scala-lang:scala-compiler:2.11.8"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ dependencies {
 description "Gradle Android Scala Plugin adds scala language support to official gradle android plugin."
 group = "com.github.xingda920813"
 version = "1.6-SNAPSHOT"
-sourceCompatibility = JavaVersion.VERSION_1_6
-targetCompatibility = JavaVersion.VERSION_1_6
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 def uploadToSonatypeRepository = hasProperty("sonatypeUserName")
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile "commons-io:commons-io:2.5"
-    testCompile "com.android.tools.build:gradle:2.3.0-beta3"
+    testCompile "com.android.tools.build:gradle:2.3.0-beta4"
     testCompile "org.scala-lang:scala-compiler:2.11.8"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile "commons-io:commons-io:2.5"
-    testCompile "com.android.tools.build:gradle:2.3.0-beta2"
+    testCompile "com.android.tools.build:gradle:2.3.0-beta3"
     testCompile "org.scala-lang:scala-compiler:2.11.8"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 }
 
 description "Gradle Android Scala Plugin adds scala language support to official gradle android plugin."
-group = "jp.leafytree.gradle"
+group = "com.github.xingda920813"
 version = "1.6-SNAPSHOT"
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6

--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,13 @@ apply plugin: "signing"
 apply plugin: "idea"
 
 repositories {
+    jcenter()
     mavenCentral()
 }
 
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
     }
 }
@@ -32,14 +34,14 @@ buildscript {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile "commons-io:commons-io:2.4"
-    testCompile "com.android.tools.build:gradle:2.0.0"
-    testCompile "org.scala-lang:scala-compiler:2.11.7"
+    compile "commons-io:commons-io:2.5"
+    testCompile "com.android.tools.build:gradle:2.3.0-beta2"
+    testCompile "org.scala-lang:scala-compiler:2.11.8"
 }
 
 description "Gradle Android Scala Plugin adds scala language support to official gradle android plugin."
 group = "jp.leafytree.gradle"
-version = "1.5-SNAPSHOT"
+version = "1.6-SNAPSHOT"
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile "commons-io:commons-io:2.5"
-    testCompile "com.android.tools.build:gradle:2.3.0-beta4"
+    testCompile "com.android.tools.build:gradle:2.3.0-rc1"
     testCompile "org.scala-lang:scala-compiler:2.11.8"
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -16,11 +16,12 @@
 apply plugin: "groovy"
 
 repositories {
+    jcenter()
     mavenCentral()
 }
 
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile "com.google.guava:guava:17.0"
+    compile "com.google.guava:guava:21.0"
 }

--- a/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
+++ b/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
@@ -35,10 +35,10 @@ public class AndroidScalaPluginIntegrationTestTask extends DefaultTask {
         ].each { projectName, runOnTravis ->
             def gradleArgs = ["clean", "connectedCheck", "uninstallAll"]
             [
-                    ["2.2.1", true,  "2.11.7", "1.3.1", "android-22", "22.0.1", "8", "23"],
-                    ["2.2.1", false, "2.10.5", "1.3.1", "android-22", "22.0.1", "8", "23"],
-                    ["2.2.1", false, "2.11.7", "1.3.1", "android-22", "22.0.1", "21", "23"],
-                    ["2.2.1", false, "2.10.5", "1.3.1", "android-22", "22.0.1", "21", "23"],
+                    ["3.3", true,  "2.11.8", "2.3.0-beta2", "android-25", "25.0.2", "8", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0-beta2", "android-25", "25.0.2", "8", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0-beta2", "android-25", "25.0.2", "21", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0-beta2", "android-25", "25.0.2", "21", "23"],
             ].each { testParameters ->
                 if (!travis || (runOnTravis && testParameters[1])) {
                     def gradleVersion = testParameters[0]
@@ -58,7 +58,7 @@ public class AndroidScalaPluginIntegrationTestTask extends DefaultTask {
                 distributionPath: "wrapper/dists",
                 zipStoreBase: "GRADLE_USER_HOME",
                 zipStorePath: "wrapper/dists",
-                distributionUrl: "http://services.gradle.org/distributions/gradle-" + gradleVersion + "-bin.zip",
+                distributionUrl: "http://services.gradle.org/distributions/gradle-" + gradleVersion + "-all.zip",
         ])
         gradleWrapperProperties
     }
@@ -73,7 +73,7 @@ public class AndroidScalaPluginIntegrationTestTask extends DefaultTask {
                 snaphotRepositoryUrl: snaphotRepositoryUrl,
                 scalaLibraryVersion: scalaLibraryVersion,
                 scalaDependencyVersion: scalaLibraryVersion.split("\\.").take(2).join("."),
-                androidScalaPluginVersion: "1.5-SNAPSHOT",
+                androidScalaPluginVersion: "1.6-SNAPSHOT",
                 androidPluginVersion: androidPluginVersion,
                 androidPluginCompileSdkVersion: androidPluginCompileSdkVersion,
                 androidPluginBuildToolsVersion: androidPluginBuildToolsVersion,

--- a/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
+++ b/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
@@ -35,10 +35,10 @@ public class AndroidScalaPluginIntegrationTestTask extends DefaultTask {
         ].each { projectName, runOnTravis ->
             def gradleArgs = ["clean", "connectedCheck", "uninstallAll"]
             [
-                    ["3.3", true,  "2.11.8", "2.3.0-beta3", "android-25", "25.0.2", "8", "23"],
-                    ["3.3", false, "2.11.8", "2.3.0-beta3", "android-25", "25.0.2", "8", "23"],
-                    ["3.3", false, "2.11.8", "2.3.0-beta3", "android-25", "25.0.2", "21", "23"],
-                    ["3.3", false, "2.11.8", "2.3.0-beta3", "android-25", "25.0.2", "21", "23"],
+                    ["3.3", true,  "2.11.8", "2.3.0-beta4", "android-25", "25.0.2", "8", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0-beta4", "android-25", "25.0.2", "8", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0-beta4", "android-25", "25.0.2", "21", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0-beta4", "android-25", "25.0.2", "21", "23"],
             ].each { testParameters ->
                 if (!travis || (runOnTravis && testParameters[1])) {
                     def gradleVersion = testParameters[0]

--- a/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
+++ b/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
@@ -35,10 +35,10 @@ public class AndroidScalaPluginIntegrationTestTask extends DefaultTask {
         ].each { projectName, runOnTravis ->
             def gradleArgs = ["clean", "connectedCheck", "uninstallAll"]
             [
-                    ["3.3", true,  "2.11.8", "2.3.0-beta4", "android-25", "25.0.2", "8", "23"],
-                    ["3.3", false, "2.11.8", "2.3.0-beta4", "android-25", "25.0.2", "8", "23"],
-                    ["3.3", false, "2.11.8", "2.3.0-beta4", "android-25", "25.0.2", "21", "23"],
-                    ["3.3", false, "2.11.8", "2.3.0-beta4", "android-25", "25.0.2", "21", "23"],
+                    ["3.3", true,  "2.11.8", "2.3.0-rc1", "android-25", "25.0.2", "8", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0-rc1", "android-25", "25.0.2", "8", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0-rc1", "android-25", "25.0.2", "21", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0-rc1", "android-25", "25.0.2", "21", "23"],
             ].each { testParameters ->
                 if (!travis || (runOnTravis && testParameters[1])) {
                     def gradleVersion = testParameters[0]

--- a/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
+++ b/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
@@ -35,10 +35,10 @@ public class AndroidScalaPluginIntegrationTestTask extends DefaultTask {
         ].each { projectName, runOnTravis ->
             def gradleArgs = ["clean", "connectedCheck", "uninstallAll"]
             [
-                    ["3.3", true,  "2.11.8", "2.3.0-rc1", "android-25", "25.0.2", "8", "23"],
-                    ["3.3", false, "2.11.8", "2.3.0-rc1", "android-25", "25.0.2", "8", "23"],
-                    ["3.3", false, "2.11.8", "2.3.0-rc1", "android-25", "25.0.2", "21", "23"],
-                    ["3.3", false, "2.11.8", "2.3.0-rc1", "android-25", "25.0.2", "21", "23"],
+                    ["3.3", true,  "2.11.8", "2.3.0", "android-25", "25.0.2", "8", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0", "android-25", "25.0.2", "8", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0", "android-25", "25.0.2", "21", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0", "android-25", "25.0.2", "21", "23"],
             ].each { testParameters ->
                 if (!travis || (runOnTravis && testParameters[1])) {
                     def gradleVersion = testParameters[0]

--- a/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
+++ b/buildSrc/src/main/groovy/jp/leafytree/gradle/AndroidScalaPluginIntegrationTestTask.groovy
@@ -35,10 +35,10 @@ public class AndroidScalaPluginIntegrationTestTask extends DefaultTask {
         ].each { projectName, runOnTravis ->
             def gradleArgs = ["clean", "connectedCheck", "uninstallAll"]
             [
-                    ["3.3", true,  "2.11.8", "2.3.0-beta2", "android-25", "25.0.2", "8", "23"],
-                    ["3.3", false, "2.11.8", "2.3.0-beta2", "android-25", "25.0.2", "8", "23"],
-                    ["3.3", false, "2.11.8", "2.3.0-beta2", "android-25", "25.0.2", "21", "23"],
-                    ["3.3", false, "2.11.8", "2.3.0-beta2", "android-25", "25.0.2", "21", "23"],
+                    ["3.3", true,  "2.11.8", "2.3.0-beta3", "android-25", "25.0.2", "8", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0-beta3", "android-25", "25.0.2", "8", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0-beta3", "android-25", "25.0.2", "21", "23"],
+                    ["3.3", false, "2.11.8", "2.3.0-beta3", "android-25", "25.0.2", "21", "23"],
             ].each { testParameters ->
                 if (!travis || (runOnTravis && testParameters[1])) {
                     def gradleVersion = testParameters[0]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk8

--- a/sample/hello/build.gradle
+++ b/sample/hello/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:1.3.1"
-        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.4"
+        classpath "com.android.tools.build:gradle:2.3.0-beta2"
+        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }
 
@@ -17,8 +18,8 @@ apply plugin: "com.android.application"
 apply plugin: "jp.leafytree.android-scala"
 
 android {
-    compileSdkVersion "android-22"
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         targetSdkVersion 22
@@ -50,12 +51,12 @@ android {
 }
 
 dependencies {
-    compile "org.scala-lang:scala-library:2.11.7"
+    compile "org.scala-lang:scala-library:2.11.8"
     compile "com.android.support:multidex:1.0.1"
     androidTestCompile "com.android.support:multidex-instrumentation:1.0.1", { exclude module: "multidex" }
 
     // to break 64k limit
-    compile "org.scalaz:scalaz-core_2.11:7.1.0"
+    compile "org.scalaz:scalaz-core_2.11:7.2.8"
     compile "com.google.guava:guava-jdk5:17.0"
-    compile "org.apache.commons:commons-math3:3.3"
+    compile "org.apache.commons:commons-math3:3.6.1"
 }

--- a/sample/hello/build.gradle
+++ b/sample/hello/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-beta2"
+        classpath "com.android.tools.build:gradle:2.3.0-beta3"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }

--- a/sample/hello/build.gradle
+++ b/sample/hello/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-beta3"
+        classpath "com.android.tools.build:gradle:2.3.0-beta4"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }

--- a/sample/hello/build.gradle
+++ b/sample/hello/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-rc1"
+        classpath "com.android.tools.build:gradle:2.3.0"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }

--- a/sample/hello/build.gradle
+++ b/sample/hello/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-beta4"
+        classpath "com.android.tools.build:gradle:2.3.0-rc1"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }

--- a/sample/hello/gradle/wrapper/gradle-wrapper.properties
+++ b/sample/hello/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/sample/libproject/app/build.gradle
+++ b/sample/libproject/app/build.gradle
@@ -2,8 +2,8 @@ apply plugin: "com.android.application"
 apply plugin: "jp.leafytree.android-scala"
 
 android {
-    compileSdkVersion "android-22"
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         targetSdkVersion 22
@@ -30,14 +30,14 @@ android {
 }
 
 dependencies {
-    compile "org.scala-lang:scala-library:2.11.7"
+    compile "org.scala-lang:scala-library:2.11.8"
     compile "com.android.support:multidex:1.0.1"
     compile project(":lib1")
     androidTestCompile "com.android.support:multidex-instrumentation:1.0.1", { exclude module: "multidex" }
 
     // to break 64k limit
-    compile "org.scalaz:scalaz-core_2.11:7.1.0"
+    compile "org.scalaz:scalaz-core_2.11:7.2.8"
     compile "com.google.guava:guava-jdk5:17.0"
-    compile "org.apache.commons:commons-math3:3.3"
+    compile "org.apache.commons:commons-math3:3.6.1"
 }
 

--- a/sample/libproject/build.gradle
+++ b/sample/libproject/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-beta2"
+        classpath "com.android.tools.build:gradle:2.3.0-beta3"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }

--- a/sample/libproject/build.gradle
+++ b/sample/libproject/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-beta3"
+        classpath "com.android.tools.build:gradle:2.3.0-beta4"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }

--- a/sample/libproject/build.gradle
+++ b/sample/libproject/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:1.3.1"
-        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.4"
+        classpath "com.android.tools.build:gradle:2.3.0-beta2"
+        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }
 

--- a/sample/libproject/build.gradle
+++ b/sample/libproject/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-rc1"
+        classpath "com.android.tools.build:gradle:2.3.0"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }

--- a/sample/libproject/build.gradle
+++ b/sample/libproject/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-beta4"
+        classpath "com.android.tools.build:gradle:2.3.0-rc1"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }

--- a/sample/libproject/gradle/wrapper/gradle-wrapper.properties
+++ b/sample/libproject/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/sample/libproject/lib1/build.gradle
+++ b/sample/libproject/lib1/build.gradle
@@ -2,8 +2,8 @@ apply plugin: "com.android.library"
 apply plugin: "jp.leafytree.android-scala"
 
 android {
-    compileSdkVersion "android-22"
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -15,7 +15,7 @@ android {
 }
 
 dependencies {
-    compile "org.scala-lang:scala-library:2.11.7"
+    compile "org.scala-lang:scala-library:2.11.8"
     compile "com.android.support:multidex:1.0.1"
     androidTestCompile "com.android.support:multidex-instrumentation:1.0.1", { exclude module: "multidex" }
 }

--- a/sample/simple/build.gradle
+++ b/sample/simple/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:1.3.1"
-        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.4"
+        classpath "com.android.tools.build:gradle:2.3.0-beta2"
+        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }
 
@@ -17,8 +18,8 @@ apply plugin: "com.android.application"
 apply plugin: "jp.leafytree.android-scala"
 
 android {
-    compileSdkVersion "android-22"
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         targetSdkVersion 22
@@ -44,6 +45,6 @@ android {
 }
 
 dependencies {
-    compile "org.scala-lang:scala-library:2.11.7"
+    compile "org.scala-lang:scala-library:2.11.8"
     compile "com.android.support:multidex:1.0.1"
 }

--- a/sample/simple/build.gradle
+++ b/sample/simple/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-beta2"
+        classpath "com.android.tools.build:gradle:2.3.0-beta3"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }

--- a/sample/simple/build.gradle
+++ b/sample/simple/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-beta3"
+        classpath "com.android.tools.build:gradle:2.3.0-beta4"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }

--- a/sample/simple/build.gradle
+++ b/sample/simple/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-rc1"
+        classpath "com.android.tools.build:gradle:2.3.0"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }

--- a/sample/simple/build.gradle
+++ b/sample/simple/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.0-beta4"
+        classpath "com.android.tools.build:gradle:2.3.0-rc1"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.6"
     }
 }

--- a/sample/simple/gradle/wrapper/gradle-wrapper.properties
+++ b/sample/simple/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/src/integTest/app/build.gradle
+++ b/src/integTest/app/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
         maven {
             url snaphotRepositoryUrl

--- a/src/integTest/appAndLib/build.gradle
+++ b/src/integTest/appAndLib/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
         maven {
             url snaphotRepositoryUrl

--- a/src/integTest/apt/build.gradle
+++ b/src/integTest/apt/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
         maven {
             url snaphotRepositoryUrl
@@ -9,7 +10,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:$androidPluginVersion"
         classpath "jp.leafytree.gradle:gradle-android-scala-plugin:$androidScalaPluginVersion"
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4+'
+        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.6'
     }
 }
 
@@ -49,7 +50,7 @@ apt {
     }
 }
 
-def AAVersion = "3.2"
+def AAVersion = "3.3.2"
 
 dependencies {
     apt "org.androidannotations:androidannotations:$AAVersion"

--- a/src/integTest/largeAppAndLib/app/build.gradle
+++ b/src/integTest/largeAppAndLib/app/build.gradle
@@ -45,10 +45,10 @@ dependencies {
     androidTestCompile "com.android.support:multidex-instrumentation:1.0.1", { exclude module: "multidex" }
 
     // to break 65535 method limitation
-    compile "org.scalaz:scalaz-core_$scalaDependencyVersion:7.0.6"
-    compile "org.apache.commons:commons-lang3:3.3.2"
-    compile "org.apache.commons:commons-math3:3.2"
+    compile "org.scalaz:scalaz-core_$scalaDependencyVersion:7.2.8"
+    compile "org.apache.commons:commons-lang3:3.5"
+    compile "org.apache.commons:commons-math3:3.6.1"
     compile "org.apache.commons:commons-io:1.3.2"
-    compile "com.google.guava:guava:16.0.1"
+    compile "com.google.guava:guava-jdk5:17.0"
     compile "com.google.code.findbugs:jsr305:2.0.3"
 }

--- a/src/integTest/largeAppAndLib/build.gradle
+++ b/src/integTest/largeAppAndLib/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
         maven {
             url snaphotRepositoryUrl

--- a/src/integTest/lib/build.gradle
+++ b/src/integTest/lib/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
         maven {
             url snaphotRepositoryUrl

--- a/src/integTest/noScala/build.gradle
+++ b/src/integTest/noScala/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
         maven {
             url snaphotRepositoryUrl

--- a/src/integTest/simpleFlavor/build.gradle
+++ b/src/integTest/simpleFlavor/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
         maven {
             url snaphotRepositoryUrl
@@ -49,11 +50,11 @@ android {
     sourceSets {
         flavor3 {
             java {
-                srcDirs = ['src/flavor3Moved/java']
+                srcDirs = []
             }
 
             scala {
-                srcDirs = ['src/flavor3Moved/scala']
+                srcDirs = ['src/flavor3Moved/java', 'src/flavor3Moved/scala']
             }
         }
     }

--- a/src/integTest/useScalaOnlyTest/build.gradle
+++ b/src/integTest/useScalaOnlyTest/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
         maven {
             url snaphotRepositoryUrl

--- a/src/main/groovy/jp/leafytree/gradle/AndroidScalaPlugin.groovy
+++ b/src/main/groovy/jp/leafytree/gradle/AndroidScalaPlugin.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 package jp.leafytree.gradle
-import com.google.common.annotations.VisibleForTesting
+//import com.google.common.annotations.VisibleForTesting
 import org.apache.commons.io.FileUtils
 import org.codehaus.groovy.runtime.InvokerHelper
 import org.gradle.api.Plugin
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicReference
  */
 public class AndroidScalaPlugin implements Plugin<Project> {
     private final FileResolver fileResolver
-    @VisibleForTesting
+    //@VisibleForTesting
     final Map<String, SourceDirectorySet> sourceDirectorySetMap = new HashMap<>()
     private Project project
     private Object androidPlugin
@@ -92,7 +92,7 @@ public class AndroidScalaPlugin implements Plugin<Project> {
         }
 
         project.tasks.withType(ScalaCompile) {
-            scalaCompileOptions.useAnt = false
+            //scalaCompileOptions.useAnt = false
         }
     }
 


### PR DESCRIPTION
Hi, saturday06.

I have made some changes to gradle-android-scala-plugin, for Gradle 3.0+ deleted useAnt option, which is deprecated in Gradle 2.x. Continue to use useAnt will prevent Gradle to compile, so I removed it and updated Gradle to 3.3.

I also updated Android Gradle Plugin to 2.3.0. From 2.2.0, it seems new version of the plugin only exists in jcenter, not in mavenCentral any more. So I changed the preferable repo to jcenter to retrieve new version of plugin. 

Scala has been updated to 2.11.8, with some other dependencies updated.

I have run integTest on my local env and passed all the tests.
